### PR TITLE
将通知表单查询逻辑移入服务层并精简控制器

### DIFF
--- a/backend/blog/src/main/java/com/lost/blog/controller/NotificationController.java
+++ b/backend/blog/src/main/java/com/lost/blog/controller/NotificationController.java
@@ -2,15 +2,7 @@ package com.lost.blog.controller;
 
 import com.lost.blog.dto.AdminFormResponse;
 import com.lost.blog.dto.NotificationResponse;
-import com.lost.blog.model.AdminForm;
-import com.lost.blog.model.Notification;
-import com.lost.blog.model.NotificationType;
-import com.lost.blog.model.User;
-import com.lost.blog.repository.AdminFormRepository;
-import com.lost.blog.repository.NotificationRepository;
-import com.lost.blog.repository.UserRepository;
 import com.lost.blog.service.NotificationService;
-import com.lost.blog.exception.ResourceNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,7 +11,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -31,23 +22,11 @@ import java.util.Map;
 @RequestMapping("/api/notifications")
 public class NotificationController {
 
-    /** 表单查找时间窗口（分钟） - 用于在通知附近时间范围内查找关联的管理表单 */
-    private static final int FORM_LOOKUP_WINDOW_MINUTES = 1;
-
     private final NotificationService notificationService;
-    private final AdminFormRepository adminFormRepository;
-    private final UserRepository userRepository;
-    private final NotificationRepository notificationRepository;
 
     @Autowired
-    public NotificationController(NotificationService notificationService,
-                                  AdminFormRepository adminFormRepository,
-                                  UserRepository userRepository,
-                                  NotificationRepository notificationRepository) {
+    public NotificationController(NotificationService notificationService) {
         this.notificationService = notificationService;
-        this.adminFormRepository = adminFormRepository;
-        this.userRepository = userRepository;
-        this.notificationRepository = notificationRepository;
     }
 
     /**
@@ -118,20 +97,7 @@ public class NotificationController {
     public ResponseEntity<AdminFormResponse> getFormByPostId(
             @PathVariable Long postId,
             @AuthenticationPrincipal UserDetails currentUser) {
-        User user = userRepository.findByUsername(currentUser.getUsername())
-                .orElseThrow(() -> new ResourceNotFoundException("未找到用户"));
-        
-        AdminForm form = adminFormRepository.findFirstByTargetUserAndPostIdOrderByCreatedAtDesc(user, postId);
-        if (form == null) {
-            throw new ResourceNotFoundException("未找到该文章的表单记录");
-        }
-        
-        AdminFormResponse response = AdminFormResponse.fromEntity(form);
-        // 隐藏管理员具体信息
-        response.setAdminId(null);
-        response.setAdminUsername(null);
-        response.setAdminNickname(null);
-        
+        AdminFormResponse response = notificationService.getFormByPostId(postId, currentUser);
         return ResponseEntity.ok(response);
     }
 
@@ -144,57 +110,7 @@ public class NotificationController {
     public ResponseEntity<AdminFormResponse> getFormByNotificationId(
             @PathVariable Long notificationId,
             @AuthenticationPrincipal UserDetails currentUser) {
-        User user = userRepository.findByUsername(currentUser.getUsername())
-                .orElseThrow(() -> new ResourceNotFoundException("未找到用户"));
-        
-        Notification notification = notificationRepository.findById(notificationId)
-                .orElseThrow(() -> new ResourceNotFoundException("未找到通知"));
-        
-        // 验证通知是属于当前用户的
-        if (!notification.getRecipient().getId().equals(user.getId())) {
-            throw new ResourceNotFoundException("无权访问此通知");
-        }
-        
-        // 只处理拒绝、文章删除和评论删除类型的通知
-        if (notification.getType() != NotificationType.POST_REJECTED && 
-            notification.getType() != NotificationType.POST_DELETED &&
-            notification.getType() != NotificationType.COMMENT_DELETED) {
-            throw new ResourceNotFoundException("此通知类型无关联表单");
-        }
-        
-        AdminForm form = null;
-        
-        // 首先尝试通过postId查找（如果文章还存在）
-        if (notification.getPost() != null) {
-            form = adminFormRepository.findFirstByTargetUserAndPostIdOrderByCreatedAtDesc(
-                    user, notification.getPost().getId());
-        }
-        
-        // 如果找不到，通过通知时间范围查找（文章已被删除的情况）
-        if (form == null) {
-            LocalDateTime notificationTime = notification.getCreatedAt();
-            // 在通知创建前后指定时间窗口内查找匹配的表单
-            LocalDateTime startTime = notificationTime.minusMinutes(FORM_LOOKUP_WINDOW_MINUTES);
-            LocalDateTime endTime = notificationTime.plusMinutes(FORM_LOOKUP_WINDOW_MINUTES);
-            
-            List<AdminForm> forms = adminFormRepository
-                    .findByTargetUserAndCreatedAtBetweenOrderByCreatedAtDesc(user, startTime, endTime);
-            
-            if (!forms.isEmpty()) {
-                form = forms.get(0);
-            }
-        }
-        
-        if (form == null) {
-            throw new ResourceNotFoundException("未找到关联的表单记录");
-        }
-        
-        AdminFormResponse response = AdminFormResponse.fromEntity(form);
-        // 隐藏管理员具体信息
-        response.setAdminId(null);
-        response.setAdminUsername(null);
-        response.setAdminNickname(null);
-        
+        AdminFormResponse response = notificationService.getFormByNotificationId(notificationId, currentUser);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/blog/src/main/java/com/lost/blog/service/NotificationService.java
+++ b/backend/blog/src/main/java/com/lost/blog/service/NotificationService.java
@@ -1,6 +1,7 @@
 package com.lost.blog.service;
 
 import com.lost.blog.dto.NotificationResponse;
+import com.lost.blog.dto.AdminFormResponse;
 import com.lost.blog.model.Comment;
 import com.lost.blog.model.Post;
 import com.lost.blog.model.User;
@@ -52,6 +53,22 @@ public interface NotificationService {
      * @return 标记为已读的通知数量
      */
     int markAllAsRead(String filter, UserDetails currentUser);
+
+    /**
+     * 获取文章关联的管理表单
+     * @param postId 文章ID
+     * @param currentUser 当前用户
+     * @return 表单详情
+     */
+    AdminFormResponse getFormByPostId(Long postId, UserDetails currentUser);
+
+    /**
+     * 根据通知ID获取关联的管理表单
+     * @param notificationId 通知ID
+     * @param currentUser 当前用户
+     * @return 表单详情
+     */
+    AdminFormResponse getFormByNotificationId(Long notificationId, UserDetails currentUser);
 
     // --- 创建通知的方法 ---
 

--- a/backend/blog/src/main/java/com/lost/blog/service/NotificationServiceImpl.java
+++ b/backend/blog/src/main/java/com/lost/blog/service/NotificationServiceImpl.java
@@ -148,7 +148,7 @@ public class NotificationServiceImpl implements NotificationService {
                 .orElseThrow(() -> new ResourceNotFoundException("未找到通知"));
 
         if (!notification.getRecipient().getId().equals(user.getId())) {
-            throw new AccessDeniedException("无权访问此通知");
+            throw new ResourceNotFoundException("未找到通知");
         }
 
         if (notification.getType() != NotificationType.POST_REJECTED

--- a/backend/blog/src/main/java/com/lost/blog/service/NotificationServiceImpl.java
+++ b/backend/blog/src/main/java/com/lost/blog/service/NotificationServiceImpl.java
@@ -1,8 +1,11 @@
 package com.lost.blog.service;
 
+import com.lost.blog.dto.AdminFormResponse;
 import com.lost.blog.dto.NotificationResponse;
+import com.lost.blog.exception.AccessDeniedException;
 import com.lost.blog.exception.ResourceNotFoundException;
 import com.lost.blog.model.*;
+import com.lost.blog.repository.AdminFormRepository;
 import com.lost.blog.repository.NotificationRepository;
 import com.lost.blog.repository.UserRepository;
 import org.slf4j.Logger;
@@ -22,18 +25,25 @@ import java.util.stream.Collectors;
 public class NotificationServiceImpl implements NotificationService {
 
     private static final Logger logger = LoggerFactory.getLogger(NotificationServiceImpl.class);
+    private static final int FORM_LOOKUP_WINDOW_MINUTES = 1;
 
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
+    private final AdminFormRepository adminFormRepository;
 
     @Autowired
     public NotificationServiceImpl(NotificationRepository notificationRepository,
-                                   UserRepository userRepository) {
+                                   UserRepository userRepository,
+                                   AdminFormRepository adminFormRepository) {
         this.notificationRepository = notificationRepository;
         this.userRepository = userRepository;
+        this.adminFormRepository = adminFormRepository;
     }
 
     private User getCurrentUser(UserDetails userDetails) {
+        if (userDetails == null) {
+            throw new AccessDeniedException("未登录");
+        }
         return userRepository.findByUsername(userDetails.getUsername())
                 .orElseThrow(() -> new ResourceNotFoundException("未找到用户: " + userDetails.getUsername()));
     }
@@ -117,6 +127,60 @@ public class NotificationServiceImpl implements NotificationService {
         } else {
             return notificationRepository.markAsReadByTypes(user, types);
         }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AdminFormResponse getFormByPostId(Long postId, UserDetails currentUser) {
+        User user = getCurrentUser(currentUser);
+        AdminForm form = adminFormRepository.findFirstByTargetUserAndPostIdOrderByCreatedAtDesc(user, postId);
+        if (form == null) {
+            throw new ResourceNotFoundException("未找到该文章的表单记录");
+        }
+        return buildFormResponse(form);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AdminFormResponse getFormByNotificationId(Long notificationId, UserDetails currentUser) {
+        User user = getCurrentUser(currentUser);
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new ResourceNotFoundException("未找到通知"));
+
+        if (!notification.getRecipient().getId().equals(user.getId())) {
+            throw new AccessDeniedException("无权访问此通知");
+        }
+
+        if (notification.getType() != NotificationType.POST_REJECTED
+                && notification.getType() != NotificationType.POST_DELETED
+                && notification.getType() != NotificationType.COMMENT_DELETED) {
+            throw new ResourceNotFoundException("此通知类型无关联表单");
+        }
+
+        AdminForm form = null;
+        if (notification.getPost() != null) {
+            form = adminFormRepository.findFirstByTargetUserAndPostIdOrderByCreatedAtDesc(
+                    user, notification.getPost().getId());
+        }
+
+        if (form == null) {
+            LocalDateTime notificationTime = notification.getCreatedAt();
+            LocalDateTime startTime = notificationTime.minusMinutes(FORM_LOOKUP_WINDOW_MINUTES);
+            LocalDateTime endTime = notificationTime.plusMinutes(FORM_LOOKUP_WINDOW_MINUTES);
+
+            List<AdminForm> forms = adminFormRepository
+                    .findByTargetUserAndCreatedAtBetweenOrderByCreatedAtDesc(user, startTime, endTime);
+
+            if (!forms.isEmpty()) {
+                form = forms.get(0);
+            }
+        }
+
+        if (form == null) {
+            throw new ResourceNotFoundException("未找到关联的表单记录");
+        }
+
+        return buildFormResponse(form);
     }
 
     // --- 创建通知的方法 ---
@@ -337,5 +401,13 @@ public class NotificationServiceImpl implements NotificationService {
             return cleanContent;
         }
         return cleanContent.substring(0, maxLength - 3) + "...";
+    }
+
+    private AdminFormResponse buildFormResponse(AdminForm form) {
+        AdminFormResponse response = AdminFormResponse.fromEntity(form);
+        response.setAdminId(null);
+        response.setAdminUsername(null);
+        response.setAdminNickname(null);
+        return response;
     }
 }


### PR DESCRIPTION
### Motivation

- 将与用户可见的“管理后台表单”查询和权限判定从控制器中抽离，以便统一处理访问控制与返回屏蔽逻辑。 
- 避免控制器直接访问仓库，降低耦合并把业务规则放到服务层以便复用和单元测试。 

### Description

- 在 `NotificationService` 中新增 `getFormByPostId` 与 `getFormByNotificationId` 接口以暴露表单查询能力并返回 `AdminFormResponse`。 
- 在 `NotificationServiceImpl` 中实现上述接口，加入登录校验、通知归属校验、通知类型校验、时间窗口查找补偿（通知关联文章已删除时），并统一通过 `buildFormResponse` 屏蔽管理员的敏感元数据；同时注入并使用 `AdminFormRepository`。 
- 精简 `NotificationController`，将原先直接访问 `AdminFormRepository` / `NotificationRepository` 的逻辑替换为调用 `NotificationService` 提供的接口，从而清晰划分控制器与服务职责。 

### Testing

- 未执行任何自动化或手动运行的测试（按请求未运行测试）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985630bb7988325bab720938988c2cb)